### PR TITLE
Add macOS SwiftUI app

### DIFF
--- a/MacApp/ContentView.swift
+++ b/MacApp/ContentView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import AppKit
+
+struct ContentView: View {
+    @State private var category = "7"
+    @State private var password = "123-45-678"
+    @State private var setupID = "1QJ8"
+    @State private var macAddress = "001122334455"
+    @State private var image: NSImage?
+    @State private var isGenerating = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Form {
+                HStack {
+                    Text("Category")
+                    TextField("Category", text: $category)
+                }
+                HStack {
+                    Text("Password")
+                    TextField("123-45-678", text: $password)
+                }
+                HStack {
+                    Text("Setup ID")
+                    TextField("1QJ8", text: $setupID)
+                }
+                HStack {
+                    Text("MAC Address")
+                    TextField("001122334455", text: $macAddress)
+                }
+            }
+            HStack {
+                Button("Generate") { generate() }
+                    .disabled(isGenerating)
+                if image != nil {
+                    Button("Save…") { save() }
+                }
+            }
+            if let img = image {
+                ScrollView {
+                    Image(nsImage: img)
+                        .interpolation(.high)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 400, maxHeight: 400)
+                        .padding()
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 480, minHeight: 520)
+    }
+
+    private func generate() {
+        isGenerating = true
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent("qrcode.png")
+        QRCodeLabelGenerator.generate(category: category, password: password, setupID: setupID, macAddress: macAddress, outputURL: temp) { img in
+            image = img
+            isGenerating = false
+        }
+    }
+
+    private func save() {
+        guard let img = image else { return }
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["png"]
+        panel.nameFieldStringValue = "qrcode.png"
+        if panel.runModal() == .OK, let url = panel.url {
+            img.pngWrite(to: url)
+        }
+    }
+}
+
+private extension NSImage {
+    func pngWrite(to url: URL) {
+        guard let tiffData = self.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let data = bitmap.representation(using: .png, properties: [:]) else { return }
+        try? data.write(to: url)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/MacApp/HomeKitQRCodeApp.swift
+++ b/MacApp/HomeKitQRCodeApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct HomeKitQRCodeApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(DefaultWindowStyle())
+    }
+}

--- a/MacApp/Package.swift
+++ b/MacApp/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "HomeKitQRCodeApp",
+    platforms: [.macOS(.v12)],
+    products: [
+        .executable(name: "HomeKitQRCodeApp", targets: ["HomeKitQRCodeApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "HomeKitQRCodeApp",
+            path: ".",
+            resources: [
+                .copy("gen_qrcode"),
+                .copy("barcode39.ttf"),
+                .copy("SF-Pro-Text-Regular.otf")
+            ]
+        )
+    ]
+)

--- a/MacApp/QRCodeLabelGenerator.swift
+++ b/MacApp/QRCodeLabelGenerator.swift
@@ -1,0 +1,33 @@
+import Foundation
+import AppKit
+
+struct QRCodeLabelGenerator {
+    static func generate(category: String, password: String, setupID: String, macAddress: String, outputURL: URL, completion: @escaping (NSImage?) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let scriptPath = Bundle.main.path(forResource: "gen_qrcode", ofType: nil) else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.currentDirectoryURL = URL(fileURLWithPath: (scriptPath as NSString).deletingLastPathComponent)
+            process.arguments = ["python3", scriptPath, category, password, setupID, macAddress, outputURL.path]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+            } catch {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            let img = NSImage(contentsOf: outputURL)
+            DispatchQueue.main.async { completion(img) }
+        }
+    }
+}

--- a/MacApp/SF-Pro-Text-Regular.otf
+++ b/MacApp/SF-Pro-Text-Regular.otf
@@ -1,0 +1,1 @@
+../SF-Pro-Text-Regular.otf

--- a/MacApp/barcode39.ttf
+++ b/MacApp/barcode39.ttf
@@ -1,0 +1,1 @@
+../barcode39.ttf

--- a/MacApp/gen_qrcode
+++ b/MacApp/gen_qrcode
@@ -1,0 +1,1 @@
+../gen_qrcode

--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ Use together with your own HomeKit firmware:
 - [Pillow](https://python-pillow.org/)
 - [qrcode](https://github.com/lincolnloop/python-qrcode)
 
+
+## macOS Application
+
+A simple SwiftUI interface is included under `MacApp/` to run the generator on macOS. Open the folder in Xcode and build **HomeKitQRCodeApp**. The app provides fields for all generator parameters, displays the rendered label and allows saving the PNG file.

--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ Use together with your own HomeKit firmware:
 
 ## macOS Application
 
-A simple SwiftUI interface is included under `MacApp/` to run the generator on macOS. Open the folder in Xcode and build **HomeKitQRCodeApp**. The app provides fields for all generator parameters, displays the rendered label and allows saving the PNG file.
+A SwiftUI application lives in the `MacApp/` directory. Open `MacApp/Package.swift` in Xcode to build **HomeKitQRCodeApp**. The package bundles the Python generator and required fonts, provides fields for all generator parameters, displays the rendered label and allows saving the PNG file.


### PR DESCRIPTION
## Summary
- add a minimal SwiftUI application under `MacApp` that runs the Python generator
- document the macOS app in the README

## Testing
- `swiftc -parse MacApp/HomeKitQRCodeApp.swift MacApp/ContentView.swift MacApp/QRCodeLabelGenerator.swift`
- `python3 -m py_compile gen_qrcode`


------
https://chatgpt.com/codex/tasks/task_e_684145f05f1c8321b85bcb50615185d2